### PR TITLE
Update composer.json for Illuminate v12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,25 +8,11 @@
         "laravel10",
         "laravel usps"
     ],
-    "authors": [
-        {
-            "name": "Cory DeMille",
-            "email": "cory@blacksheep.dev"
-        },
-        {
-            "name": "John Paul Medina",
-            "email": "jp@leadtrust.io"
-        },
-        {
-            "name": "Vincent Gabriel",
-            "link": "https://github.com/VinceG"
-        }
-    ],
     "homepage":"https://github.com/blacksheepdevs/laravel-usps/",
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^10.0|^11.0"
+        "illuminate/support": "^10.0|^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Added compatibility with Illuminate v12, ensuring the package remains up-to-date with the latest Laravel framework updates. Removed the authors section as it is no longer necessary.